### PR TITLE
fix calculation error for ',' as decimal point

### DIFF
--- a/src/com/android/calculator2/CalculatorExpressionEvaluator.java
+++ b/src/com/android/calculator2/CalculatorExpressionEvaluator.java
@@ -57,7 +57,7 @@ public class CalculatorExpressionEvaluator {
 
         try {
             String result = mSolver.solve(expr);
-            callback.onEvaluate(expr, result, Calculator.INVALID_RES_ID);
+            callback.onEvaluate(expr, mTokenizer.getLocalizedExpression(result), Calculator.INVALID_RES_ID);
         } catch (SyntaxException e) {
             callback.onEvaluate(expr, null, R.string.error);
         }

--- a/src/com/android/calculator2/CalculatorExpressionTokenizer.java
+++ b/src/com/android/calculator2/CalculatorExpressionTokenizer.java
@@ -28,8 +28,8 @@ public class CalculatorExpressionTokenizer {
 
     public CalculatorExpressionTokenizer(Context context) {
         mReplacements = new LinkedList<Localizer>();
-        mReplacements.add(new Localizer(".", String.valueOf(Constants.DECIMAL_POINT)));
         mReplacements.add(new Localizer(",", String.valueOf(Constants.MATRIX_SEPARATOR)));
+        mReplacements.add(new Localizer(".", String.valueOf(Constants.DECIMAL_POINT)));
         mReplacements.add(new Localizer("0", context.getString(R.string.digit0)));
         mReplacements.add(new Localizer("1", context.getString(R.string.digit1)));
         mReplacements.add(new Localizer("2", context.getString(R.string.digit2)));


### PR DESCRIPTION
Expressions were normalized but weren't localized after they were solved.
Imagine:
',' as decimal point
'.' as decimal separator

',' was normalized to '.' but was never localized again.
TextChangedListener in CalculatorEditText took '.' as decimal separator and removed it.

The order of the replacements in CalculatorExpressionTokenizer had to be changed because '.' would have been localized to ',' and after that it would have been localized to the matrix separator.

PS: Please excuse my english.
